### PR TITLE
Drop deprecated generation of source features and include all sources

### DIFF
--- a/features/org.eclipse.emf.mwe.core-feature/pom.xml
+++ b/features/org.eclipse.emf.mwe.core-feature/pom.xml
@@ -9,26 +9,4 @@
 	<version>1.20.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 	<artifactId>org.eclipse.emf.mwe.core.feature</artifactId>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-source-plugin</artifactId>
-				<version>${tycho-version}</version>
-				<executions>
-					<execution>
-						<id>feature-source</id>
-						<goals>
-							<goal>feature-source</goal>
-						</goals>
-						<configuration>
-							<excludes>
-								<plugin id="org.apache.commons.cli" />
-							</excludes>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/features/org.eclipse.emf.mwe.doc-feature/pom.xml
+++ b/features/org.eclipse.emf.mwe.doc-feature/pom.xml
@@ -12,24 +12,4 @@
 	<packaging>eclipse-feature</packaging>
 	<artifactId>org.eclipse.emf.mwe.doc.feature</artifactId>
 	<name>${project.artifactId}</name>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-source-plugin</artifactId>
-				<version>${tycho-version}</version>
-				<executions>
-					<execution>
-						<id>feature-source</id>
-						<goals>
-							<goal>feature-source</goal>
-						</goals>
-						<configuration>
-							<skip>true</skip>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/features/org.eclipse.emf.mwe.sdk-feature/feature.xml
+++ b/features/org.eclipse.emf.mwe.sdk-feature/feature.xml
@@ -38,16 +38,6 @@ SPDX-License-Identifier: EPL-2.0
          version="0.0.0"/>
 
    <includes
-         id="org.eclipse.emf.mwe.core.feature.source"
-         version="0.0.0"
-         optional="true"/>
-
-   <includes
-         id="org.eclipse.emf.mwe.ui.feature.source"
-         version="0.0.0"
-         optional="true"/>
-
-   <includes
          id="org.eclipse.emf.mwe.doc.feature"
          version="0.0.0"/>
 

--- a/features/org.eclipse.emf.mwe.sdk-feature/pom.xml
+++ b/features/org.eclipse.emf.mwe.sdk-feature/pom.xml
@@ -9,24 +9,4 @@
 	<version>1.20.0-SNAPSHOT</version>
 	<packaging>eclipse-feature</packaging>
 	<artifactId>org.eclipse.emf.mwe.sdk</artifactId>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-source-plugin</artifactId>
-				<version>${tycho-version}</version>
-				<executions>
-					<execution>
-						<id>feature-source</id>
-						<goals>
-							<goal>feature-source</goal>
-						</goals>
-						<configuration>
-							<skip>true</skip>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/features/org.eclipse.emf.mwe2.language.sdk-feature/feature.xml
+++ b/features/org.eclipse.emf.mwe2.language.sdk-feature/feature.xml
@@ -37,10 +37,6 @@ SPDX-License-Identifier: EPL-2.0
          id="org.eclipse.emf.mwe2.launcher"
          version="0.0.0"/>
 
-   <includes
-         id="org.eclipse.emf.mwe2.launcher.source"
-         version="0.0.0"/>
-
    <requires>
       <import feature="org.eclipse.xtext.ui" version="2.34.0" match="compatible"/>
    </requires>

--- a/features/org.eclipse.emf.mwe2.language.sdk-feature/pom.xml
+++ b/features/org.eclipse.emf.mwe2.language.sdk-feature/pom.xml
@@ -8,24 +8,4 @@
 	</parent>
 	<packaging>eclipse-feature</packaging>
 	<artifactId>org.eclipse.emf.mwe2.language.sdk</artifactId>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-source-plugin</artifactId>
-				<version>${tycho-version}</version>
-				<executions>
-					<execution>
-						<id>feature-source</id>
-						<goals>
-							<goal>feature-source</goal>
-						</goals>
-						<configuration>
-							<skip>true</skip>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/features/org.eclipse.emf.mwe2.runtime.sdk-feature/pom.xml
+++ b/features/org.eclipse.emf.mwe2.runtime.sdk-feature/pom.xml
@@ -8,24 +8,4 @@
 	</parent>
 	<packaging>eclipse-feature</packaging>
 	<artifactId>org.eclipse.emf.mwe2.runtime.sdk</artifactId>
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-source-plugin</artifactId>
-				<version>${tycho-version}</version>
-				<executions>
-					<execution>
-						<id>feature-source</id>
-						<goals>
-							<goal>feature-source</goal>
-						</goals>
-						<configuration>
-							<skip>true</skip>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
 </project>

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -26,19 +26,6 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.eclipse.tycho</groupId>
-				<artifactId>tycho-source-plugin</artifactId>
-				<version>${tycho-version}</version>
-				<executions>
-					<execution>
-						<id>feature-source</id>
-						<goals>
-							<goal>feature-source</goal>
-						</goals>
-					</execution>
-				</executions>
-			</plugin>
-			<plugin>
 				<groupId>org.eclipse.cbi.maven.plugins</groupId>
 				<artifactId>eclipse-jarsigner-plugin</artifactId>
 				<executions>

--- a/maven/org.eclipse.emf.mwe2.repository/category.xml
+++ b/maven/org.eclipse.emf.mwe2.repository/category.xml
@@ -7,13 +7,9 @@
       <category name="mwe2lang"/>
    </feature>
    <bundle id="com.google.guava" version="33.5.0.qualifier"/>
-   <bundle id="com.google.guava.source" version="33.5.0.qualifier"/>
    <bundle id="com.google.guava.failureaccess" version="1.0.3.qualifier"/>
-   <bundle id="com.google.guava.failureaccess.source" version="1.0.3.qualifier"/>
    <bundle id="org.apache.commons.cli" version="1.11.0"/>
-   <bundle id="org.apache.commons.cli.source" version="1.11.0"/>
    <bundle id="org.apache.commons.commons-logging" version="0.0.0"/>
-   <bundle id="org.apache.commons.commons-logging.source" version="0.0.0"/>
    <category-def name="mwe2lang" label="MWE">
       <description>
          The configuration language used to configure Xtext&apos;s code generator.

--- a/maven/org.eclipse.emf.mwe2.repository/pom.xml
+++ b/maven/org.eclipse.emf.mwe2.repository/pom.xml
@@ -29,6 +29,7 @@
 				<configuration>
 					<repositoryName>MWE Repository</repositoryName>
 					<finalName>${final.repo.name}</finalName>
+					<includeAllSources>true</includeAllSources>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
The `tycho-source:feature-source` mojo is deprecated. Instead `tycho-p2-repository:assemble-repository` should be configured with `includeAllSources=true` to just include all source bundles in assembled p2-repositories.

See also
- https://tycho.eclipseprojects.io/doc/5.0.2/tycho-source-plugin/feature-source-mojo.html
- https://github.com/eclipse-tycho/tycho/discussions/5265
