### PR TITLE
[RelEng] Remove explicit versions from p2-repository

### DIFF
--- a/maven/org.eclipse.emf.mwe2.repository/category.xml
+++ b/maven/org.eclipse.emf.mwe2.repository/category.xml
@@ -6,10 +6,10 @@
    <feature id="org.eclipse.emf.mwe.sdk" version="0.0.0">
       <category name="mwe2lang"/>
    </feature>
-   <bundle id="com.google.guava" version="33.5.0.qualifier"/>
-   <bundle id="com.google.guava.failureaccess" version="1.0.3.qualifier"/>
-   <bundle id="org.apache.commons.cli" version="1.11.0"/>
-   <bundle id="org.apache.commons.commons-logging" version="0.0.0"/>
+   <bundle id="com.google.guava"/>
+   <bundle id="com.google.guava.failureaccess"/>
+   <bundle id="org.apache.commons.cli"/>
+   <bundle id="org.apache.commons.commons-logging"/>
    <category-def name="mwe2lang" label="MWE">
       <description>
          The configuration language used to configure Xtext&apos;s code generator.


### PR DESCRIPTION
Instead include the latest version of mentioned dependencies.

No version and `0.0.0` are equivalent.